### PR TITLE
Add a more intuitive error message to Table::add_row

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -143,7 +143,7 @@ impl Table {
     pub fn add_row(&mut self, row: Row) -> &mut Self {
         let cells = row.0;
 
-        assert_eq!(cells.len(), self.n_columns);
+        assert_eq!(cells.len(), self.n_columns, "Number of columns in table and row don't match");
 
         for (width, s) in self.column_widths.iter_mut().zip(cells.iter()) {
             *width = ::std::cmp::max(*width, s.width());


### PR DESCRIPTION
Hello! I found this project recently and it really nicely fit a niche that I needed filled.

One thing that I got stuck on, however, was an error message which only told me that 5 was not equal to 6. I used the debugger and found the source: `assert_eq` is used to determine whether the number of cells in the table is equal to the number of cells in the row to be added. This wasn't intuitive to me, so I decided to create a pull request to make this error more obvious.

I'm fairly new to the rust community, so I'm not sure if the way I have added this is actually best practice, but I figured I may as well start the discussion by being productive.

Thank you for your time.