### PR TITLE
add methods for cells with ANSI escapes and custom widths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.31.0
+  - 1.46.0
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,8 @@ edition = "2018"
 default = ["unicode-width"]
 
 [dependencies]
+strip-ansi-escapes = "0.1.1"
 unicode-width = { version = "0.1.5", optional = true }
+
+[dev-dependencies]
+colored = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ tabular = { version = "0.1.4", default-features = false }
 Note that without `unicode-width`, alignment will be based on the count of the
 `std::str::Chars` iterator.
 
-This crate supports Rust version 1.31.0 and later.
+This crate supports Rust version 1.46.0 and later.
 
 ## See also
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! Note that without `unicode-width`, alignment will be based on the count of the
 //! `std::str::Chars` iterator.
 //!
-//! This crate supports Rust version 1.31.0 and later.
+//! This crate supports Rust version 1.46.0 and later.
 //!
 //! # See also
 //!

--- a/src/row.rs
+++ b/src/row.rs
@@ -38,7 +38,7 @@ use std::fmt::{Debug, Display, Formatter};
 /// [`Row::from_cells()`]: struct.Row.html#method.from_cells
 /// [`Row::with_cell()`]: struct.Row.html#method.with_cell
 #[derive(Clone, Default)]
-pub struct Row(pub (crate) Vec<WidthString>);
+pub struct Row(pub(crate) Vec<WidthString>);
 
 impl Row {
     /// Makes a new, empty table row.
@@ -83,6 +83,41 @@ impl Row {
         self
     }
 
+    /// Adds a cell to this table row after stripping ANSI escape sequences.
+    ///
+    /// If the table is being printed out to a terminal that supports ANSI escape sequences,
+    /// cell widths need to account for that.
+    pub fn with_ansi_cell<S: Display>(mut self, value: S) -> Self {
+        self.add_ansi_cell(value);
+        self
+    }
+
+    /// Adds a cell to this table row with a custom width.
+    ///
+    /// Similar to [`with_ansi_cell`], except it returns `&mut Self` rather than `Self`.
+    pub fn add_ansi_cell<S: Display>(&mut self, value: S) -> &mut Self {
+        self.0.push(WidthString::new_ansi(value));
+        self
+    }
+
+    /// Adds a cell to this table row with a custom width.
+    ///
+    /// Cell widths are normally calculated by looking at the string. In some cases, such as if the
+    /// string contains escape sequences of some sort, users may wish to specify a specific width
+    /// to use for a custom cell.
+    pub fn with_custom_width_cell<S: Display>(mut self, value: S, width: usize) -> Self {
+        self.add_custom_width_cell(value, width);
+        self
+    }
+
+    /// Adds a cell to this table row with a custom width.
+    ///
+    /// Similar to [`with_custom_width_cell`], except it returns `&mut Self` rather than `Self`.
+    pub fn add_custom_width_cell<S: Display>(&mut self, value: S, width: usize) -> &mut Self {
+        self.0.push(WidthString::custom_width(value, width));
+        self
+    }
+
     /// Builds a row from an iterator over strings.
     ///
     /// # Examples
@@ -123,12 +158,17 @@ impl Row {
     /// });
     /// ```
     pub fn from_cells<S, I>(values: I) -> Self
-        where S: Into<String>,
-              I: IntoIterator<Item = S> {
-
-        Row(values.into_iter().map(Into::into).map(WidthString::new).collect())
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        Row(values
+            .into_iter()
+            .map(Into::into)
+            .map(WidthString::new)
+            .collect())
     }
-    
+
     /// The number of cells in this row.
     ///
     /// # Examples
@@ -187,4 +227,3 @@ pub enum InternalRow {
     Cells(Vec<WidthString>),
     Heading(String),
 }
-

--- a/src/width_string.rs
+++ b/src/width_string.rs
@@ -9,11 +9,25 @@ pub struct WidthString {
 impl WidthString {
     pub fn new<T: ToString>(thing: T) -> Self {
         let string = thing.to_string();
-        #[cfg(feature = "unicode-width")]
-        let width  = ::unicode_width::UnicodeWidthStr::width(string.as_str());
-        #[cfg(not(feature = "unicode-width"))]
-        let width  = string.chars().count();
+        let width = Self::compute_width(&string);
         WidthString { string, width }
+    }
+
+    pub fn new_ansi<T: ToString>(thing: T) -> Self {
+        let string = thing.to_string();
+        let stripped_bytes =
+            strip_ansi_escapes::strip(&string).expect("writing to a Cursor<Vec<u8>> is infallible");
+        let stripped_string = String::from_utf8(stripped_bytes)
+            .expect("a UTF-8 string with ANSI escapes stripped is valid UTF-8");
+        let width = Self::compute_width(&stripped_string);
+        WidthString { string, width }
+    }
+
+    pub fn custom_width<T: ToString>(thing: T, width: usize) -> Self {
+        WidthString {
+            string: thing.to_string(),
+            width,
+        }
     }
 
     pub fn width(&self) -> usize {
@@ -22,6 +36,16 @@ impl WidthString {
 
     pub fn as_str(&self) -> &str {
         &self.string
+    }
+
+    #[cfg(feature = "unicode-width")]
+    fn compute_width(s: &str) -> usize {
+        unicode_width::UnicodeWidthStr::width(s)
+    }
+
+    #[cfg(not(feature = "unicode-width"))]
+    fn compute_width(s: &str) -> usize {
+        s.chars().count()
     }
 }
 
@@ -37,5 +61,21 @@ impl Default for WidthString {
             string: String::new(),
             width: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::width_string::WidthString;
+    use colored::Colorize;
+
+    #[test]
+    fn ansi() {
+        let s = "blue";
+        assert_eq!(WidthString::new_ansi(s).width, 4);
+        let colored = s.blue();
+        assert_eq!(WidthString::new_ansi(&colored).width, 4);
+        let bolded = colored.bold();
+        assert_eq!(WidthString::new_ansi(&bolded).width, 4);
     }
 }


### PR DESCRIPTION
Add optional methods for:
* cells with ANSI escapes
* cells with custom widths

This is a variant of #6, except stripping ANSI escapes is now opt-in.

As requested in #6, please let me know if the crate is still maintained, otherwise I'm always happy to release a fork on crates.io (with proper attribution of course!)